### PR TITLE
Fixes to export_level1

### DIFF
--- a/gnssice/export_level1.py
+++ b/gnssice/export_level1.py
@@ -114,7 +114,7 @@ def load_sort(args):
     
     geod = pd.concat(geod_store, axis=0)
     geod = geod.sort_index()
-    ndups = len(geod.index.duplicated())
+    ndups = geod.index.duplicated().sum()
     print(f'Removing {ndups} duplicated rows across the combined data bales')
     geod = geod[~geod.index.duplicated()]
 


### PR DESCRIPTION
This PR fixes:
- Use of regular expression for finding bales files (previously the regex was being supplied to glob which is incorrect, now we use re.match)
- Fix calculation and printing of number of duplicates.