### PR TITLE
Level 1 export fix

### DIFF
--- a/gnssice/export_level1.py
+++ b/gnssice/export_level1.py
@@ -168,7 +168,6 @@ def remove_old_files(newfile, args):
             if Path(f).name == Path(newfile).name:
                 continue
             else:
-                print("here else")
                 print(f'Found old Level-1 file {f}, deleting')
                 os.remove(f)
     else:

--- a/gnssice/export_level1.py
+++ b/gnssice/export_level1.py
@@ -86,7 +86,7 @@ def load_sort(args):
     else:
         data_root = os.environ['GNSS_L1DIR']
     if args.geod_file is None:
-        path_to_data = os.path.join(data_root, args.site)
+        path_to_data = os.path.join(data_root, args.site)     
         print(f'Searching {path_to_data} for standard-format parquet bales...')
         files = [os.path.join(path_to_data, f) for f in os.listdir(path_to_data) if re.match(pp.REGEX_GEOD_BALE_FILE, f)]
     elif len(args.geod_file) == 1:
@@ -160,18 +160,19 @@ def export(args, geod):
     return geod_out
 
 def remove_old_files(newfile, args):
-
-    path_to_data = os.path.join(os.environ['GNSS_L1DIR'], args.site, pp.REGEX_L1_FILE)
-    print(f'Searching {path_to_data}...')
-    files = glob(path_to_data)
+    path_to_data = os.path.join(os.environ['GNSS_L1DIR'], args.site)
+    print(f'Searching {path_to_data} for deleting old files...')
+    files = [os.path.join(path_to_data, f) for f in os.listdir(path_to_data) if re.match(pp.REGEX_L1_FILE, f)]
     if len(files) > 1:
         for f in files:
             if Path(f).name == Path(newfile).name:
                 continue
             else:
+                print("here else")
                 print(f'Found old Level-1 file {f}, deleting')
                 os.remove(f)
-
+    else:
+        print('No old Level-1 files found')
     return 
 
 

--- a/gnssice/pp.py
+++ b/gnssice/pp.py
@@ -29,8 +29,8 @@ ELLPS_B = 6356752.3142
 # First numerical eccentricity
 ELLPS_E2 = 1.0 - math.pow((ELLPS_B/ELLPS_A), 2)
 
-REGEX_GEOD_BALE_FILE = r'[a-z0-9]{4}\_[a-z0-9]{4}\_[0-9]{4}\_[0-9]{3}\_[0-9]{3}_GEOD.parquet'
-REGEX_L1_FILE = r'[a-z0-9]{4}\_[0-9]{4}\_[0-9]{3}\_[0-9]{4}\_[0-9]{3}_geod.parquet'
+REGEX_GEOD_BALE_FILE = r'[a-z0-9]{4}\_[a-z0-9]{4}\_[0-9]{4}\_[0-9]{1,3}\_[0-9]{1,3}_GEOD.parquet'
+REGEX_L1_FILE = r'[a-z0-9]{4}\_[0-9]{4}\_[0-9]{1,3}\_[0-9]{4}\_[0-9]{1,3}_geod.parquet'
 
 
 def update_legacy_geod_col_names(df):


### PR DESCRIPTION
pp.py
- fixed REGEX_GEOD_BALE_FILE and REGEX_L1_FILE to allow for 1-3 digit DOYs in parquet file names

export_level1.py
- in remove_old_files() function
- fixed how regex files names are read
- improved console print (to disntinguish what "Searching for..." does
- however, not sure whether remove_old_files() is needed as we replace old parquet files already in export()??

And sorry, L171 in export_level1.py needs to be removed