### PR TITLE
Add download support for RINEX from 3rd parties

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,21 +257,28 @@ cat igs364.sp3 igs365.sp3 igs001.sp3 > igs365.sp3
 ```
    
 
-#### Optional: Get 3rd party base RINEX files.
+#### Optional: Base RINEX files from GNET (KLSQ)
 
-If required, obtain RINEX files from another site to cover the gaps.
+In Greenland, GNET stations can often serve as the base for post-processing. These data are publicly available via the Danish Government, https://dataforsyningen.dk/data/4804. Data access is via FTP (ftps://ftp.dataforsyningen.dk/GNSS/GRL) following account registration at the Danish Govt at the link above. 
 
-Sometimes 3rd party base files can be downloaded directly from public archives using the GAMIT/GLOBK script `sh_get_rinex`: 
+*Option 1:* Use the collection of three scripts that we've developed to download batches of data - all in the subfolder `rinex_helpers/`. Use them in the following order:
 
-```bash
-sh_get_rinex -archive sopac -yr 2011 -doy 0 -ndays 250 -sites kely
-```
+1. `dk_rinex_generate_list.py --start [date] --end [date]`: Given a date range, this creates a list of download URLs for the FTPS server (default called `urls.txt`).
+2. `dk_rinex_download_list.sh`: Supply with the `urls.txt` file, and make sure your FTPS credentials are placed in the `--user` option of the `curl` command in this script)
+3. `dk_rinex_to_rnx2.sh`: Converts the 1-second RINEX3 files to 10-second RINEX2-named files (contents is still RINEX3).
 
-In Greenland, GNET stations can often serve as the base for post-processing. These data are publicly available via the Danish Government, https://dataforsyningen.dk/data/4804. Data access is via FTP (ftps://ftp.dataforsyningen.dk/GNSS/GRL) following account registration at the Danish Govt. link above. Use an FTP client such as FileZilla to download the files of interest. You will likely need to download the 1-second resolution files. You may then need to reduce them to 10-second resolution using a tool such as `gfzrnx`.
+*Option 2:* Use an FTP client such as FileZilla to download the files of interest. You will likely need to download the 1-second resolution files. You may then need to reduce them to 10-second resolution using a tool such as `gfzrnx`.
+
+*Then:* In both cases, overlap if necessary using `process_rinex`.
+
+
+##### Optional: Base RINEX files from GEUS (LRHP)
 
 Data from stations maintained by the Geological Survey of Denmark and Greenland (GEUS), e.g. at Point 660, can in principle be obtained from the GEUS DataVerse, but if unavailable then individual contact may be needed.
 
-**Important:** all filenames need to be in lowercase. Files from the GEUS DataVerse may be in uppercase, in which it is essential to rename them to lowercase:
+Use the script `rinex_helpers/geus_rinex_download.py`. If the files are shared privately then you will need to supply this script with the access token.
+
+*Important:** Files from the GEUS DataVerse may be in uppercase, in which it is essential to rename them to lowercase:
 
 ```bash
 for a_file in *;do mv -v "$a_file" `echo "$a_file" | tr [:upper:] [:lower:]` ;done;
@@ -292,6 +299,14 @@ Now overlap/window RINEX files using the `R` file type argument to `process_rine
 process_rinex <site> R -overlap
 ```
 
+
+#### Optional: Other 3rd party base RINEX files.
+
+Sometimes 3rd party base files can be downloaded directly from public archives using the GAMIT/GLOBK script `sh_get_rinex`: 
+
+```bash
+sh_get_rinex -archive sopac -yr 2011 -doy 0 -ndays 250 -sites kely
+```
 
 #### IONEX files
 

--- a/gnssice/export_level1.py
+++ b/gnssice/export_level1.py
@@ -123,7 +123,7 @@ def load_sort(args):
     print(geod.tail())
     
     plt.figure()
-    plt.plot(geod.index, geod.Latitude_deg, 'o')
+    plt.plot(geod.index, geod.Latitude_deg, '.', alpha=0.2)
     plt.show()
     
     return geod

--- a/rinex_helpers/dk_rinex_download_list.sh
+++ b/rinex_helpers/dk_rinex_download_list.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Download files listed in urls.txt (one URL per line) using curl.
+# Skips blank lines and comments (lines starting with #).
+#
+# Usage:
+#   chmod +x download_files.sh
+#   ./download_files.sh [urls_file] [output_dir]
+#
+# Defaults:
+#   urls_file  = urls.txt        (in the same directory as this script)
+#   output_dir = ./downloads
+# Insert your username-password combination below or save in a .netrc file
+# Written by Andrew Tedstone with Claude AI, March 2026
+
+set -euo pipefail
+
+URLS_FILE="${1:-urls.txt}"
+OUTPUT_DIR="${2:-./downloads}"
+
+if [[ ! -f "$URLS_FILE" ]]; then
+  echo "Error: URL file '$URLS_FILE' not found." >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+total=0
+success=0
+failed=0
+failed_urls=()
+
+while IFS= read -r url || [[ -n "$url" ]]; do
+  # Skip blank lines and comments
+  [[ -z "$url" || "$url" == \#* ]] && continue
+
+  total=$((total + 1))
+  filename=$(basename "$url")
+  dest="$OUTPUT_DIR/$filename"
+
+  echo "[${total}] Downloading: $filename"
+
+  if curl \
+      --silent \
+      --show-error \
+      --fail \
+      --ftp-ssl \
+      --user "user:password" \
+      --output "$dest" \
+      "$url"; then
+    echo "    ✓ Saved to $dest"
+    success=$((success + 1))
+  else
+    echo "    ✗ Failed: $url" >&2
+    failed=$((failed + 1))
+    failed_urls+=("$url")
+    rm -f "$dest"   # remove incomplete file
+  fi
+
+done < "$URLS_FILE"
+
+echo ""
+echo "Done. ${success}/${total} files downloaded successfully to '$OUTPUT_DIR'."
+
+if [[ ${#failed_urls[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed URLs (${failed}):"
+  printf '  %s\n' "${failed_urls[@]}"
+  exit 1
+fi

--- a/rinex_helpers/dk_rinex_generate_list.py
+++ b/rinex_helpers/dk_rinex_generate_list.py
@@ -1,0 +1,89 @@
+"""
+Generate GNSS RINEX3 file URLs for download from the Danish dataforsyningen FTP server.
+
+URL format:
+  ftps://ftp.dataforsyningen.dk/GNSS/RINEX3/GRL/{year}/{doy}/{station}{country}_R_{year}{doy}0000_01D_01S_MO.crx.gz
+
+Usage examples:
+  # Single date
+  python generate_gnss_filenames.py --start 2025-02-09
+
+  # Date range
+  python generate_gnss_filenames.py --start 2025-01-01 --end 2025-03-31
+
+  # Custom station/country
+  python generate_gnss_filenames.py --start 2025-02-09 --station KLSQ --country GRL
+
+  # Save URLs to a file
+  python generate_gnss_filenames.py --start 2025-01-01 --end 2025-12-31 --output urls.txt
+"""
+
+import argparse
+from datetime import date, timedelta
+
+
+BASE_URL = "ftps://ftp.dataforsyningen.dk/GNSS/RINEX3/{country}/{year}/{doy:03d}"
+FILENAME  = "{station}00{country}_R_{year}{doy:03d}0000_01D_01S_MO.crx.gz"
+
+
+def build_url(target_date: date, station: str = "KLSQ", country: str = "GRL") -> str:
+    """Return the full FTP URL for a given date, station and country."""
+    year = target_date.year
+    doy  = target_date.timetuple().tm_yday          # day-of-year, 1-based
+
+    directory = BASE_URL.format(country=country, year=year, doy=doy)
+    filename  = FILENAME.format(station=station.upper(), country=country.upper(),
+                                year=year, doy=doy)
+    return f"{directory}/{filename}"
+
+
+def generate_urls(start: date, end: date,
+                  station: str = "KLSQ", country: str = "GRL") -> list[str]:
+    """Generate one URL per day for [start, end] inclusive."""
+    urls = []
+    current = start
+    while current <= end:
+        urls.append(build_url(current, station, country))
+        current += timedelta(days=1)
+    return urls
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate GNSS RINEX3 FTP download URLs by date range."
+    )
+    parser.add_argument("--start",   required=True,
+                        help="Start date in YYYY-MM-DD format")
+    parser.add_argument("--end",     default=None,
+                        help="End date in YYYY-MM-DD format (default: same as --start)")
+    parser.add_argument("--station", default="KLSQ",
+                        help="4-character station code (default: KLSQ)")
+    parser.add_argument("--country", default="GRL",
+                        help="3-character country/region code (default: GRL)")
+    parser.add_argument("--output",  default=None,
+                        help="Write URLs to this file instead of stdout")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    start = date.fromisoformat(args.start)
+    end   = date.fromisoformat(args.end) if args.end else start
+
+    if end < start:
+        raise SystemExit("Error: --end must not be before --start.")
+
+    urls = generate_urls(start, end, station=args.station, country=args.country)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write("\n".join(urls) + "\n")
+        print(f"Wrote {len(urls)} URL(s) to {args.output}")
+    else:
+        for url in urls:
+            print(url)
+
+
+if __name__ == "__main__":
+    main()

--- a/rinex_helpers/dk_rinex_to_rnx2.sh
+++ b/rinex_helpers/dk_rinex_to_rnx2.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Convert a folder of 1-second RINEX3 observation files to 10-second RINEX2
+# files using gfzrnx, with automatic RINEX2 filename convention output.
+#
+# Supports all combinations of input file types:
+#   .crx.gz  (Hatanaka + gzip)  → gunzip to tmp, crx2rnx to tmp, gfzrnx
+#   .crx     (Hatanaka only)    → crx2rnx to tmp, gfzrnx
+#   .rnx.gz  (gzip only)        → gunzip to tmp, gfzrnx
+#   .rnx     (plain)            → gfzrnx directly
+#
+# Usage:
+#   chmod +x convert_rinex3_to_rinex2_10s.sh
+#   ./convert_rinex3_to_rinex2_10s.sh [input_dir] [output_dir]
+#
+# Defaults:
+#   input_dir  = .
+#   output_dir = .
+#
+# Author: Andrew Tedstone, March 2026 using Claude AI
+
+set -euo pipefail
+
+INPUT_DIR="${1:-.}"
+OUTPUT_DIR="${2:-.}"
+SAMPLING=10   # output sampling rate in seconds
+TMP_DIR=$(mktemp -d)
+
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+if [[ ! -d "$INPUT_DIR" ]]; then
+  echo "Error: input directory '$INPUT_DIR' not found." >&2
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+# Collect all RINEX3 observation files (compressed or plain)
+mapfile -t files < <(find "$INPUT_DIR" -maxdepth 1 -type f \
+  \( -name "*_MO.crx.gz" -o -name "*_MO.rnx.gz" \
+     -o -name "*_MO.crx"  -o -name "*_MO.rnx"  \) | sort)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No RINEX3 observation files found in '$INPUT_DIR'." >&2
+  exit 1
+fi
+
+total=${#files[@]}
+success=0
+failed=0
+failed_files=()
+
+echo "Found ${total} file(s) in '$INPUT_DIR'."
+echo "Converting to ${SAMPLING}s RINEX2 → '$OUTPUT_DIR'"
+echo ""
+
+for filepath in "${files[@]}"; do
+  filename=$(basename "$filepath")
+  echo "[$(( success + failed + 1 ))/${total}] Processing: $filename"
+
+  # Decompress to a temp file so gfzrnx always receives a real file path.
+  # After each iteration the tmp dir is cleared, keeping disk use low.
+  gfzrnx_input="$filepath"   # default: use file directly (plain .rnx)
+
+  case "$filename" in
+    *.crx.gz)
+      tmp_rnx="$TMP_DIR/${filename%.crx.gz}.rnx"
+      if ! gunzip -c "$filepath" | crx2rnx - > "$tmp_rnx"; then
+        echo "    ✗ Failed to decompress/decode: $filename" >&2
+        failed=$(( failed + 1 )); failed_files+=("$filename"); continue
+      fi
+      gfzrnx_input="$tmp_rnx"
+      ;;
+    *.crx)
+      tmp_rnx="$TMP_DIR/${filename%.crx}.rnx"
+      if ! crx2rnx - < "$filepath" > "$tmp_rnx"; then
+        echo "    ✗ Failed to decode Hatanaka: $filename" >&2
+        failed=$(( failed + 1 )); failed_files+=("$filename"); continue
+      fi
+      gfzrnx_input="$tmp_rnx"
+      ;;
+    *.rnx.gz)
+      tmp_rnx="$TMP_DIR/${filename%.gz}"
+      if ! gunzip -c "$filepath" > "$tmp_rnx"; then
+        echo "    ✗ Failed to decompress: $filename" >&2
+        failed=$(( failed + 1 )); failed_files+=("$filename"); continue
+      fi
+      gfzrnx_input="$tmp_rnx"
+      ;;
+    *.rnx)
+      gfzrnx_input="$filepath"   # no decompression needed
+      ;;
+    *)
+      echo "    ✗ Unrecognised file type, skipping: $filename" >&2
+      failed=$(( failed + 1 )); failed_files+=("$filename"); continue
+      ;;
+  esac
+
+  if gfzrnx \
+      -finp  "$gfzrnx_input" \
+      -fout  "${OUTPUT_DIR}/::RX2::" \
+      -vo    2 \
+      -smp   "$SAMPLING" \
+      -f; then
+    echo "    ✓ Done"
+    success=$(( success + 1 ))
+  else
+    echo "    ✗ gfzrnx failed: $filename" >&2
+    failed=$(( failed + 1 ))
+    failed_files+=("$filename")
+  fi
+
+  # Clear tmp dir between iterations to avoid accumulating large files
+  rm -f "$TMP_DIR"/*
+
+done
+
+echo ""
+echo "Done. ${success}/${total} file(s) converted successfully to '$OUTPUT_DIR'."
+
+if [[ ${#failed_files[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed files (${failed}):"
+  printf '  %s\n' "${failed_files[@]}"
+  exit 1
+fi

--- a/rinex_helpers/geus_rinex_download.py
+++ b/rinex_helpers/geus_rinex_download.py
@@ -1,0 +1,56 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: ipynb,py:percent
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.4
+#   kernelspec:
+#     display_name: Python 3 (ipykernel)
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Download GEUS Russell GNSS base station data 
+#
+# Data are obtained from draft GEUS Dataverse dataset. We have access to this via a Dataverse key provided especially.
+#
+#
+# Andrew Tedstone, September 2025
+
+# %%
+import json
+import requests
+import os
+
+# %%
+SAVE_TO = '/work/atedstone/gnss_2024_2025/lrhp/'
+headers = {
+    'X-Dataverse-key':'INSERT_KEY_HERE'
+}
+
+response = requests.get('https://dataverse.geus.dk/api/datasets/:persistentId/versions/:draft?persistentId=doi:10.22008/FK2/QIGJCR', 
+                       headers=headers)
+listing = json.loads(response.content)
+
+
+# %%
+files = listing['data']['files']
+
+for f in files:
+    # Get the Dataverse file ID (which is not the same thing as the filename)
+    fid = f['dataFile']['id']
+    # Get the filename, which we will use to save the file locally
+    fname = f['label']
+    # Skip the NAV files, we only want the compressed OBS files
+    if fname[-1] != 'D':
+        continue
+        
+    print(fname)
+    
+    with open(os.path.join(SAVE_TO, fname), 'wb') as fh:
+        response = requests.get(f'https://dataverse.geus.dk/api/access/datafile/{fid}', headers=headers)
+        fh.write(response.content)


### PR DESCRIPTION
This PR adds basic support for acquiring base station RINEX files from:
- GEUS
- dataforsyningen

Intended for use with GNSS stations LRHP and KLSQ respectively.